### PR TITLE
Feat: dockerfiles tools docs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ gen:
 .PHONY: generate
 generate: tools gen
 
-.PHONY: run
-run: build up
+.PHONY: docker
+docker: build up
 
 .PHONY: build-deps
 build-deps:
@@ -36,3 +36,8 @@ build: build-deps
 up:
 	@echo Starting up
 	@docker-compose up
+
+.PHONY: down
+down:
+	@echo Shutting down
+	@docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
+.DEFAULT_GOAL := tools
+
+.PHONY: download
 download:
 	@echo Download go.mod dependencies
 	@go mod download
 	@go mod tidy
 
+.PHONY: tools
 tools: download
 	@echo Installing tools from tools.go
 	@cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
 
+.PHONY: gen
 gen: 
 	@echo Go generate
 	@go generate ./...
 
+.PHONY: generate
 generate: tools gen

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,21 @@ gen:
 
 .PHONY: generate
 generate: tools gen
+
+.PHONY: run
+run: build up
+
+.PHONY: build-deps
+build-deps:
+	@echo Building dependencies image
+	@docker build -t deps -f ./deps.dockerfile .
+
+.PHONY: build
+build: build-deps
+	@echo Building images
+	@docker-compose build
+
+.PHONY: up
+up:
+	@echo Starting up
+	@docker-compose up

--- a/account/cmd.dockerfile
+++ b/account/cmd.dockerfile
@@ -1,15 +1,9 @@
-# TODO:
-
-# Make 3-stages build:
-#   1. Load dependencies from go.mod
-#   2. Build server binary
-#   3. Transfer binaries to buster-slim
-
-FROM golang:1.16.3-buster AS deps
-WORKDIR /deps
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-
 FROM deps AS build
-COPY . .
+WORKDIR /build
+COPY --from=deps /deps .
+COPY account account
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /bin/account ./account/cmd
+
+FROM debian:buster-slim AS bin
+COPY --from=build /bin/account /bin/account
+ENTRYPOINT [ "/bin/account" ]

--- a/account/cmd.dockerfile
+++ b/account/cmd.dockerfile
@@ -4,3 +4,12 @@
 #   1. Load dependencies from go.mod
 #   2. Build server binary
 #   3. Transfer binaries to buster-slim
+
+FROM golang:1.16.3-buster AS deps
+WORKDIR /deps
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+FROM deps AS build
+COPY . .

--- a/deps.dockerfile
+++ b/deps.dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.16.3-buster AS deps
+WORKDIR /deps
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY pub pub

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,9 @@ services:
     environment:
       GRAPHQL_PORT: 9100
       ACCOUNT_SERVICE_URL: account:9100
+      GRAPHQL_DEPLOYMENT: docker
+      GRAPHQL_RELEASE: 1
+      GRAPHQL_VERSION: v0.0.1
     volumes:
       - ./:/services
     networks:
@@ -40,6 +43,8 @@ services:
       ACCOUNT_PORT: 9100
       ACCOUNT_DSN: postgres://cocopuff:123456@account_db/cocopuff?sslmode=disable
       ACCOUNT_DEPLOYMENT: docker
+      ACCOUNT_RELEASE: 1
+      ACCOUNT_VERSION: v0.0.1
     volumes:
       - ./:/services
     networks:
@@ -54,6 +59,8 @@ services:
       POSTGRES_DB: cocopuff
       POSTGRES_USER: cocopuff
       POSTGRES_PASSWORD: 123456
+    networks:
+      - coconet
     restart: unless-stopped
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,42 +1,49 @@
 services:
+  deps:
+    image: deps
+    build:
+      context: .
+      dockerfile: ./deps.dockerfile
+
   graphql:
-    container_name: graphql
-    image: golang:latest
-    networks:
-      - coconet
+    build:
+      context: .
+      dockerfile: ./graphql/cmd.dockerfile
     depends_on:
+      - deps
       - account
     expose:
       - "9100"
     ports:
       - "9100:9100"
-    volumes:
-      - ./:/services
     environment:
       GRAPHQL_PORT: 9100
       ACCOUNT_SERVICE_URL: account:9100
-    working_dir: /services
-    command: "go run graphql/cmd/main.go"
+    volumes:
+      - ./:/services
+    networks:
+      - coconet
     restart: on-failure
 
   account:
     build:
       context: .
       dockerfile: ./account/cmd.dockerfile
-    networks:
-        - coconet
     depends_on:
+      - deps
       - account_db
     expose:
       - "9100"
     ports:
       - "9099:9100"
-    volumes:
-      - ./:/services
     environment:
       ACCOUNT_PORT: 9100
       ACCOUNT_DSN: postgres://cocopuff:123456@account_db/cocopuff?sslmode=disable
       ACCOUNT_DEPLOYMENT: docker
+    volumes:
+      - ./:/services
+    networks:
+      - coconet
     restart: on-failure
 
   account_db:

--- a/flows/structure.md
+++ b/flows/structure.md
@@ -77,6 +77,9 @@
   > make download
   > make tools
   >```
+* deps.dockerfile
+  > Image with all dependencies of the project.  
+  > Is tagged as `deps`.
 * docker-compose.yaml
 * .github
 * .gitignore

--- a/flows/structure.md
+++ b/flows/structure.md
@@ -37,7 +37,7 @@
     >   ```go
     >   go.mod
     >   go.sum
-    >   go download
+    >   go mod download
     >   ```
     > - stage 2: build service.  
     >   ```dockerfile

--- a/graphql/cmd.dockerfile
+++ b/graphql/cmd.dockerfile
@@ -1,0 +1,9 @@
+FROM deps AS build
+WORKDIR /build
+COPY --from=deps /deps .
+COPY graphql graphql
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /bin/graphql ./graphql/cmd
+
+FROM debian:buster-slim AS bin
+COPY --from=build /bin/graphql /bin/graphql
+ENTRYPOINT [ "/bin/graphql" ]


### PR DESCRIPTION
* Staged image builds:
  1. Image from `deps.dockerfile` keeps all `go.mod` dependencies
  2. `cmd.dockerfile`'s are per service and are staged to `build` from `deps` and run from `buster-slim`

* Makefile docker support

* `docker-compose` fixes

* Improved documentation